### PR TITLE
Fix shebang

### DIFF
--- a/sshh
+++ b/sshh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 session_name=$(tmux display-message -p '#{session_name}')
 window_index=$(tmux display-message -p '#{window_index}')


### PR DESCRIPTION
Was getting en error saying "marked as an executable but could not be run by the operating system", see https://github.com/fish-shell/fish-shell/issues/4946. 

This fixes that failure.