### PR TITLE
Support et and mosh as alternative ssh commands

### DIFF
--- a/sshh
+++ b/sshh
@@ -3,6 +3,7 @@
 session_name=$(tmux display-message -p '#{session_name}')
 window_index=$(tmux display-message -p '#{window_index}')
 pane_index=0
+ssh_cmds="ssh mosh et"
 
 if [ -n "$1" ]; then
     w=$(echo "$1" | awk -F ',' '{ print $1 }')
@@ -37,7 +38,8 @@ pane_pid=$(echo "${target_pane}" | awk '{ print $2 }')
 IFS=$'\n'
 for child_pid in $(pgrep -P ${pane_pid}); do
     child_cmd=$(ps ${child_pid} | tail -n 1 | awk '{for(i=5;i<NF;i++) printf("%s ",$i); print $NF}')
-    if [ $(echo "${child_cmd}" | awk '{ print $1 }') = 'ssh' ]; then
+    if [[ " $ssh_cmds " =~ " $(echo "${child_cmd}" | awk '{ print $1 }') " ]];
+    then
         echo "${child_cmd}"
         eval "exec ${child_cmd}"
     else


### PR DESCRIPTION
Instead of just checking that the command is ssh, check whether it is any of `ssh`, `et` or `mosh`. This way the user won't have to press `y` when using `sshh` with these tools. 

Implemented the "list membership" functionality with help from [this](https://stackoverflow.com/questions/8063228/how-do-i-check-if-a-variable-exists-in-a-list-in-bash#comment60490124_8063398) stackoverflow post

Tested on my remote `et` connection and it works flawlessly